### PR TITLE
Fixed bug while send result to main process if socket already closed

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Mojo::IOLoop::ForkCall
 
+0.11 2014-07-08
+  - Fixed bug while send result to main process if socket already closed
+
 0.10 2014-07-04
   - Child now resets the IOLoop
   - Bump Mojolicious version to 5.08

--- a/lib/Mojo/IOLoop/ForkCall.pm
+++ b/lib/Mojo/IOLoop/ForkCall.pm
@@ -27,7 +27,7 @@ sub run {
   $args = shift if @_ and ref $_[0] eq 'ARRAY';
   $cb   = shift if @_;
 
-  my ($r, $w) = pipely; 
+  my ($r, $w) = pipely;
 
   my $pid = fork;
   die "Failed to fork: $!" unless defined $pid;
@@ -107,9 +107,17 @@ sub _send {
   if (IS_WINDOWS || IS_CYGWIN) {
     my $len = length $data;
     my $written = 0;
-    $written += syswrite $h, $data, 65536, $written while $written < $len;
+    while ($written < $len) {
+      my $count = syswrite $h, $data, 65536, $written;
+      unless (defined $count) {
+        warn $!;
+        last;
+      }
+      $written += $count;
+    }
   } else {
-    syswrite $h, $data;
+    my $count = syswrite $h, $data;
+    warn $! unless defined $count;
   }
 }
 


### PR DESCRIPTION
Sometimes I get this error on windows: `Use of uninitialized value in addition (+) at C:/strawberry/perl/site/lib/Mojo/IOLoop/ForkCall.pm line 110.`

This patch handles error from syswrite, but I can't write corresponding tests for this
