### PR TITLE
Creating manually a Mojo::IOLoop->delay to work with Mojolicious 7.90

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Mojo::IOLoop::ForkCall
 
+0.20 2018-09-12
+  - delay helper has been removed from Mojolicious 7.90 -> creating manually a Mojo::IOLoop->delay
+
 0.19 2018-02-13
   - Protect against changes in Mojo::IOLoop::Delay->catch
 

--- a/lib/Mojolicious/Plugin/ForkCall.pm
+++ b/lib/Mojolicious/Plugin/ForkCall.pm
@@ -18,7 +18,7 @@ sub register {
     my $cb = pop;
     my @args = @_;
 
-    $c->delay(
+    Mojo::IOLoop->delay(
       sub{
         my $end = shift->begin;
         my $once = sub { $end->(@_) if $end; undef $end };


### PR DESCRIPTION
Mojolicious::Plugin::ForkCall doesn't work on new version of Mojolicious since delay is not anymore an instance method.